### PR TITLE
- Round of improvements for next version

### DIFF
--- a/LocalRiderInstallations.cs
+++ b/LocalRiderInstallations.cs
@@ -1,0 +1,123 @@
+﻿using System.Text.RegularExpressions;
+
+namespace RiderWorkFlow
+{
+    public partial class LocalRiderInstallations
+    {
+        public const string OptionsFilePath = @"/options/recentSolutions.xml";
+
+        public static string GetLatestRiderVersion()
+        {
+            string[] roots = new string[]
+            {
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)
+            };
+
+            string? latestVersion = null;
+            var latest = new Version(0, 0, 0);
+
+            foreach (var root in roots)
+            {
+                var jetbrainsDir = Path.Combine(root, "JetBrains");
+                if (!Directory.Exists(jetbrainsDir))
+                    continue;
+
+                foreach (var dir in Directory.GetDirectories(jetbrainsDir, "JetBrains Rider*"))
+                {
+                    var folderName = Path.GetFileName(dir);
+                    // Match "2025", "2025.1", or "2025.1.5"
+                    var match = RiderVersionRegex().Match(folderName);
+                    if (!match.Success)
+                        continue;
+
+                    int year = int.Parse(match.Groups[1].Value);
+                    int minor = match.Groups[2].Success ? int.Parse(match.Groups[2].Value) : 0;
+                    int patch = match.Groups[3].Success ? int.Parse(match.Groups[3].Value) : 0;
+
+                    var version = new Version(year, minor, patch);
+
+                    if (version <= latest) continue;
+
+                    latest = version;
+                    latestVersion = version.ToString();
+                }
+            }
+
+            if (latestVersion == null)
+                throw new InvalidOperationException("No JetBrains Rider installation found.");
+
+            return latestVersion;
+        }
+
+        public static string GetRiderExecutablePath(string version)
+        {
+            if (string.IsNullOrWhiteSpace(version))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(version));
+
+            string[] roots = new string[]
+            {
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)
+            };
+
+            foreach (var root in roots)
+            {
+                var jetbrainsDir = Path.Combine(root, "JetBrains");
+                if (!Directory.Exists(jetbrainsDir))
+                    continue;
+
+                foreach (var dir in Directory.GetDirectories(jetbrainsDir, $"JetBrains Rider*{version}*"))
+                {
+                    var exePath = Path.Combine(dir, "bin", "rider64.exe");
+                    if (File.Exists(exePath))
+                        return exePath;
+                }
+            }
+
+            throw new InvalidOperationException($"Rider executable for version {version} not found.");
+        }
+
+        public static string GetRiderRecentSolutionsFilePath()
+        {
+            var appDataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "JetBrains");
+            if (!Directory.Exists(appDataFolder))
+                throw new InvalidOperationException("JetBrains AppData folder not found.");
+
+            var latest = new Version(0, 0, 0);
+            string? folderWithLatestVersion = null;
+            foreach (var dir in Directory.GetDirectories(appDataFolder, "Rider*"))
+            {
+                var folderName = Path.GetFileName(dir);
+                // Match "2025", "2025.1", or "2025.1.5"
+                var match = RiderVersionRegex().Match(folderName);
+                if (!match.Success)
+                    continue;
+
+                int year = int.Parse(match.Groups[1].Value);
+                int minor = match.Groups[2].Success ? int.Parse(match.Groups[2].Value) : 0;
+                int patch = match.Groups[3].Success ? int.Parse(match.Groups[3].Value) : 0;
+
+                var version = new Version(year, minor, patch);
+
+                if (version <= latest) continue;
+
+                latest = version;
+                folderWithLatestVersion = folderName;
+            }
+
+
+            if (folderWithLatestVersion == null)
+                throw new InvalidOperationException("No Rider AppData folder found matching version.");
+
+            var optionsFile = Path.Combine(appDataFolder, folderWithLatestVersion, "options", "recentSolutions.xml");
+
+            return File.Exists(optionsFile)
+                ? optionsFile
+                : throw new FileNotFoundException("Recent solutions file not found.", optionsFile);
+        }
+
+        [GeneratedRegex(@"(\d{4})(?:\.(\d+))?(?:\.(\d+))?")]
+        private static partial Regex RiderVersionRegex();
+    }
+}

--- a/ProjectManager.cs
+++ b/ProjectManager.cs
@@ -8,13 +8,14 @@ public class ProjectManager
 {
     private const string IcoPath = "Images/Icon.png";
     private const string IDEName = "rider";
+    private const string UserHomePlaceholder = "$USER_HOME$";
     private readonly string _optionPath;
 
     public ProjectManager()
     {
         _optionPath = GetOptionPath();
     }
-    
+
     public List<Result> GetResultProjects(string projectName)
     {
         return GetProjects(projectName)
@@ -26,18 +27,30 @@ public class ProjectManager
                 Action = (c) => OpenProject(e.ProjectPath)
             }).ToList();
     }
-    
+
     private List<ProjectModel> GetProjects(string projectName)
     {
         var xmlContent = File.ReadAllText(_optionPath);
         var xmlDoc = XDocument.Parse(xmlContent);
         var names = xmlDoc.Descendants("entry")
-            .Select(e => new ProjectModel{ ProjectPath = e.Attribute("key")!.Value })
-            .Where(e => e.Name.ToLower().Contains(projectName.ToLower())).ToList();
-        
+            .Select(e => new ProjectModel { ProjectPath = FixPathForWindows(ReplaceUserHome(e.Attribute("key")!.Value)) })
+            .Where(e => e.Name.Contains(projectName, StringComparison.CurrentCultureIgnoreCase)).ToList();
+
         return names;
     }
-    
+
+    private static string ReplaceUserHome(string path)
+    {
+        if (string.IsNullOrEmpty(path)) return path;
+        return path.Replace(UserHomePlaceholder, Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+    }
+
+    private static string FixPathForWindows(string path)
+    {
+        if (string.IsNullOrEmpty(path)) return path;
+        return path.Replace("/", "\\");
+    }
+
     private static bool OpenProject(string solutionPath)
     {
         var processStartInfo = new ProcessStartInfo
@@ -61,11 +74,11 @@ public class ProjectManager
     {
         var applicationDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\JetBrains\";
         const string optionsFilePath = @"\options\recentSolutions.xml";
-        
+
         var riderVersion = Directory.GetDirectories(applicationDataFolder)
             .Select(Path.GetFileName)
-            .FirstOrDefault(e => e != null && e.ToLower().Contains(IDEName));
-        
+            .FirstOrDefault(e => e != null && e.Contains(IDEName, StringComparison.CurrentCultureIgnoreCase));
+
         return applicationDataFolder + riderVersion + optionsFilePath;
     }
 }


### PR DESCRIPTION
Fixes in this PR:
- fixed opening projects with path set with `$USER_HOME$` in `recentSolutions.xml`
- since FlowLauncher is a windows application we can always default path to be split by `\`
- optimized some string comparisons by not creating new strings in memory
- always use the latest version of Rider
- explicitly execute solutions with the latest Rider executable in case solution is not associated with Rider
